### PR TITLE
Fix status parsing bug

### DIFF
--- a/commands/install.cmd
+++ b/commands/install.cmd
@@ -62,7 +62,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     echo "nameserver 127.0.0.1" | sudo tee /etc/resolver/test >/dev/null
   fi
 else
-  warning "Manual configuration required for Automatic DNS resolution: ttps://dockergiant.github.io/rolldev/configuration/dns-resolver.html"
+  warning "Manual configuration required for Automatic DNS resolution: https://dockergiant.github.io/rolldev/configuration/dns-resolver.html"
 fi
 
 ## generate rsa keypair for authenticating to roll sshd service

--- a/commands/status.cmd
+++ b/commands/status.cmd
@@ -28,10 +28,10 @@ for projectNetwork in "${projectNetworkList[@]}"; do
     [[ -z "${container}" ]] && continue # Project is not running, skip it
 
     projectDir=$(docker container inspect --format '{{ index .Config.Labels "com.docker.compose.project.working_dir"}}' "$container")
-    projectName=$(cat "${projectDir}/.env.roll" | grep '^ROLL_ENV_NAME=' | sed -e 's/ROLL_ENV_NAME=[[:space:]]*//g' | tr -d -)
-    projectType=$(cat "${projectDir}/.env.roll" | grep '^ROLL_ENV_TYPE=' | sed -e 's/ROLL_ENV_TYPE=[[:space:]]*//g' | tr -d -)
-    traefikDomain=$(cat "${projectDir}/.env.roll" | grep '^TRAEFIK_DOMAIN=' | sed -e 's/TRAEFIK_DOMAIN=[[:space:]]*//g' | tr -d -)
-    traefikSubDomain=$(cat "${projectDir}/.env.roll" | grep '^TRAEFIK_SUBDOMAIN=' | sed -e 's/TRAEFIK_SUBDOMAIN=[[:space:]]*//g' | tr -d -)
+    projectName=$(cat "${projectDir}/.env.roll" | grep '^ROLL_ENV_NAME=' | sed -e 's/ROLL_ENV_NAME=[[:space:]]*//g' | tr -d '\r')
+    projectType=$(cat "${projectDir}/.env.roll" | grep '^ROLL_ENV_TYPE=' | sed -e 's/ROLL_ENV_TYPE=[[:space:]]*//g' | tr -d '\r')
+    traefikDomain=$(cat "${projectDir}/.env.roll" | grep '^TRAEFIK_DOMAIN=' | sed -e 's/TRAEFIK_DOMAIN=[[:space:]]*//g' | tr -d '\r')
+    traefikSubDomain=$(cat "${projectDir}/.env.roll" | grep '^TRAEFIK_SUBDOMAIN=' | sed -e 's/TRAEFIK_SUBDOMAIN=[[:space:]]*//g' | tr -d '\r')
 
     messageList+=("    \033[1;35m${projectName}\033[0m a \033[36m${projectType}\033[0m project")
     messageList+=("       Project Directory: \033[33m${projectDir}\033[0m")


### PR DESCRIPTION
## Summary
- fix Windows CRLF detection in `status` command
- fix docs URL in `install` command

## Testing
- `bash -n commands/status.cmd`
- `bash -n commands/install.cmd`


------
https://chatgpt.com/codex/tasks/task_e_6841679fce58832c8899516a9f4ce7cc