### PR TITLE
Fix typo in redis usage

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -45,7 +45,7 @@ Flush redis completely:
 
     roll redis flushall
 
-Run redis continous stat mode
+Run redis continuous stat mode
 
     roll redis --stat
 


### PR DESCRIPTION
## Summary
- correct a typo in `docs/usage.md`

## Testing
- `pip install --user -r requirements.txt`
- `make html`

------
https://chatgpt.com/codex/tasks/task_e_68416aa772a4832c93c4d95c3fe43179