### PR TITLE
Fix comment wording

### DIFF
--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -234,7 +234,7 @@ then
     roll sync pause
 fi
 
-## pass ochestration through to docker-compose
+## pass orchestration through to docker-compose
 docker compose \
     --env-file "${ROLL_ENV_PATH}/.env.roll" --project-directory "${ROLL_ENV_PATH}" -p "${ROLL_ENV_NAME}" \
     "${DOCKER_COMPOSE_ARGS[@]}" "${ROLL_PARAMS[@]}" "$@"

--- a/commands/svc.cmd
+++ b/commands/svc.cmd
@@ -92,7 +92,7 @@ fi
 
 ROLL_VERSION=$(cat ${ROLL_DIR}/version)
 
-## pass ochestration through to docker-compose
+## pass orchestration through to docker-compose
 ROLL_VERSION=${ROLL_VERSION:-"in-dev"} docker compose \
     --project-directory "${ROLL_HOME_DIR}" -p roll \
     "${DOCKER_COMPOSE_ARGS[@]}" "${ROLL_PARAMS[@]}" "$@"


### PR DESCRIPTION
## Summary
- fix wording in env and svc command comments

## Testing
- `bash -n commands/env.cmd`
- `bash -n commands/svc.cmd`


------
https://chatgpt.com/codex/tasks/task_e_68416aa90408832cbd2e7f165717b78f